### PR TITLE
fix unicode apostrophe

### DIFF
--- a/magclassic/templates/emails/guest_food_info.txt
+++ b/magclassic/templates/emails/guest_food_info.txt
@@ -11,7 +11,7 @@ The first meal served will be breakfast on Friday morning, and the suite will re
 
 Meal schedule, menu, and suite rules can all be found at http://magsuite.jennytru.com/.
 
-Don’t forget to fill out your food restrictions. Please let us know if you have any questions.
+Don't forget to fill out your food restrictions. Please let us know if you have any questions.
 
 We look forward to seeing you in the Staff Suite!
 


### PR DESCRIPTION
this had a unicode apostrophe that I think we were choking on.

error was 
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 984: invalid start byte
```