### PR TITLE
Use epoch for emails when appropriate

### DIFF
--- a/magclassic/automated_emails.py
+++ b/magclassic/automated_emails.py
@@ -7,9 +7,9 @@ AutomatedEmail(Attendee, 'MAGFest hospitality suite information', 'guest_food_in
            lambda a: a.badge_type == c.GUEST_BADGE,
            sender="MAGFest Staff Suite <chefs@magfest.org>")
 AutomatedEmail(Attendee, 'MAGFest Volunteer Food', 'volunteer_food_info.txt',
-           lambda a: a.staffing and days_before(7, c.UBER_TAKEDOWN),
+           lambda a: a.staffing and days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)),
            sender="MAGFest Staff Suite <chefs@magfest.org>")
 AutomatedEmail(Attendee, 'MAGClassic Check-in Barcode', 'checkin_barcode.html',
-               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.UBER_TAKEDOWN))
+               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)))
 AutomatedEmail(Attendee, 'MAGClassic FAQ', 'prefest_faq.html',
-               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.UBER_TAKEDOWN))
+               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)))

--- a/magclassic/automated_emails.py
+++ b/magclassic/automated_emails.py
@@ -7,9 +7,9 @@ AutomatedEmail(Attendee, 'MAGFest hospitality suite information', 'guest_food_in
            lambda a: a.badge_type == c.GUEST_BADGE,
            sender="MAGFest Staff Suite <chefs@magfest.org>")
 AutomatedEmail(Attendee, 'MAGFest Volunteer Food', 'volunteer_food_info.txt',
-           lambda a: a.staffing and days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)),
+           lambda a: a.staffing and days_before(7, c.DEFAULT_EMAIL_DEADLINE),
            sender="MAGFest Staff Suite <chefs@magfest.org>")
 AutomatedEmail(Attendee, 'MAGClassic Check-in Barcode', 'checkin_barcode.html',
-               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)))
+               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.DEFAULT_EMAIL_DEADLINE))
 AutomatedEmail(Attendee, 'MAGClassic FAQ', 'prefest_faq.html',
-               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)))
+               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.DEFAULT_EMAIL_DEADLINE))

--- a/magclassic/automated_emails.py
+++ b/magclassic/automated_emails.py
@@ -7,9 +7,9 @@ AutomatedEmail(Attendee, 'MAGFest hospitality suite information', 'guest_food_in
            lambda a: a.badge_type == c.GUEST_BADGE,
            sender="MAGFest Staff Suite <chefs@magfest.org>")
 AutomatedEmail(Attendee, 'MAGFest Volunteer Food', 'volunteer_food_info.txt',
-           lambda a: a.staffing and days_before(7, c.DEFAULT_EMAIL_DEADLINE),
+           lambda a: a.staffing and days_before(7, c.FINAL_EMAIL_DEADLINE),
            sender="MAGFest Staff Suite <chefs@magfest.org>")
 AutomatedEmail(Attendee, 'MAGClassic Check-in Barcode', 'checkin_barcode.html',
-               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.DEFAULT_EMAIL_DEADLINE))
+               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.FINAL_EMAIL_DEADLINE))
 AutomatedEmail(Attendee, 'MAGClassic FAQ', 'prefest_faq.html',
-               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.DEFAULT_EMAIL_DEADLINE))
+               lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.FINAL_EMAIL_DEADLINE))


### PR DESCRIPTION
The usage of uber_takedown has changed now that we often don't take down the system. This keeps emails from getting sent too late even if we decide to set uber_takedown to be after the start of the event (which is more accurate to reality).