### PR TITLE
improved fix for https://github.com/magfest/ubersystem/pull/1842/files

### DIFF
--- a/magclassic/automated_emails.py
+++ b/magclassic/automated_emails.py
@@ -1,5 +1,9 @@
 from magclassic import *
 
+# With "MAGFest Laboratories" as a new event, we find that the phrasing "Staffing again"
+# doesn't differentiate this event, so we remove it.
+AutomatedEmail.instances['Want to staff {}?'.format(c.EVENT_NAME)] = AutomatedEmail.instances.pop('Want to staff {} again?'.format(c.EVENT_NAME))
+
 AutomatedEmail(Attendee, 'MAGFest food for guests', 'guest_food_restrictions.txt',
            lambda a: a.badge_type == c.GUEST_BADGE,
            sender="MAGFest Staff Suite <chefs@magfest.org>")


### PR DESCRIPTION
An improved fix for https://github.com/magfest/ubersystem/pull/1842/files

Related to the creation of our new event MAGLabs, -- the Subject line of our Staffing Email reads:
"Want to staff (event_name) again?"

With MAGFest Laboratories as a new event, we find that the phrasing "Staffing again" doesn't differentiate this event from other events.  This removes "again" from the subject line in the email.