### PR TITLE
Hide sandwich preferences for MAGLabs

### DIFF
--- a/magclassic/templates/baseextra.html
+++ b/magclassic/templates/baseextra.html
@@ -1,5 +1,7 @@
 {% if c.PAGE_PATH == '/signups/food_restrictions' %}
     <script type="text/javascript">
+    // Hide sandwich preferences, since we don't need to collect them for MAGLabs.
+    // We check all the boxes to bypass a validation in the main codebase.
     $("#sandwich_prefs").hide();
     $("input[name='sandwich_pref']").prop('checked', true);
     </script>

--- a/magclassic/templates/baseextra.html
+++ b/magclassic/templates/baseextra.html
@@ -1,0 +1,6 @@
+{% if c.PAGE_PATH == '/signups/food_restrictions' %}
+    <script type="text/javascript">
+    $("#sandwich_prefs").hide();
+    $("input[name='sandwich_pref']").prop('checked', true);
+    </script>
+{% endif %}


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/1935 by:
Putting the sandwich preferences in a div with a unique ID in the core plugin.
Hiding said div with jQuery in the magclassic plugin.
Setting all sandwich preferences to checked in the magclassic plugin; this is to bypass a validation check.